### PR TITLE
feat: generate html report and deploy via pages

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -1,0 +1,38 @@
+name: Build Web Report
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - run: pip install -r requirements.txt
+      - run: python scripts/build_report.py --output dist/index.html
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ venv/
 .env
 
 # Data (tracked)
+
+dist/

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BLACK=$(VENV)/bin/black
 RUFF=$(VENV)/bin/ruff
 PYTEST=$(VENV)/bin/pytest
 
-.PHONY: dev install format lint test run run-benchmarks clean hook
+.PHONY: dev install format lint test run run-benchmarks report clean hook
 
 $(PY):
 	python3 -m venv $(VENV)
@@ -36,7 +36,10 @@ run: $(PY)
 	$(PY) sortino.py
 
 run-benchmarks: $(PY)
-	$(PY) sortino.py --benchmarks
+        $(PY) sortino.py --benchmarks
+
+report: $(PY)
+        $(PY) scripts/build_report.py
 
 clean:
 	rm -rf $(VENV) __pycache__ .pytest_cache .coverage htmlcov

--- a/README.md
+++ b/README.md
@@ -49,6 +49,20 @@ make run-benchmarks
 # or: ./venv/bin/python sortino.py --benchmarks
 ```
 
+## Web UI
+
+Generate a static HTML report with a simple Chart.js visualization:
+
+```bash
+make report
+# or: ./venv/bin/python scripts/build_report.py --output dist/index.html
+```
+
+Merging to `main` runs the `Build Web Report` workflow, which regenerates
+`dist/index.html` and deploys it to GitHub Pages. After enabling Pages
+(`Settings` → `Pages` → `Build and deployment` → `GitHub Actions`), the
+latest report is served at `https://<your-user>.github.io/capital/`.
+
 ## Test
 
 ```bash

--- a/scripts/build_report.py
+++ b/scripts/build_report.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+
+from sortino import (
+    ANNUAL_RF_RATE,
+    JSON_FILE_PATH,
+    convert_to_monthly_and_calculate_ratios,
+)
+
+
+def _fmt_pct(x: float) -> str:
+    """Format a number as percentage."""
+    return f"{x * 100:.2f}%" if pd.notna(x) else "na"
+
+
+def _fmt_val(x: float) -> str:
+    """Format a number with two decimals."""
+    return f"{x:.2f}" if pd.notna(x) else "na"
+
+
+def render_html(monthly_returns: pd.Series, metrics: dict[str, float]) -> str:
+    """Render a simple HTML report with a Chart.js plot and metrics table."""
+    labels = [str(m) for m in monthly_returns.index]
+    data = [round(v * 100, 2) for v in monthly_returns]
+
+    rows = [
+        ("CAGR", _fmt_pct(metrics["cagr"])),
+        ("Max Monthly Drawdown", _fmt_pct(metrics["max_dd_monthly"])),
+        ("YTD", _fmt_pct(metrics["ytd"])),
+        ("Sharpe", _fmt_val(metrics["sharpe"])),
+        ("Sortino", _fmt_val(metrics["sortino"])),
+    ]
+    table_rows = "\n".join(
+        f"<tr><th>{name}</th><td>{val}</td></tr>" for name, val in rows
+    )
+
+    html = f"""<!DOCTYPE html>
+<html>
+<head>
+  <meta charset=\"utf-8\" />
+  <title>Portfolio Performance</title>
+  <script src=\"https://cdn.jsdelivr.net/npm/chart.js\"></script>
+</head>
+<body>
+  <h1>Portfolio Monthly Returns</h1>
+  <canvas id=\"returnsChart\"></canvas>
+  <script>
+    const ctx = document.getElementById('returnsChart').getContext('2d');
+    new Chart(ctx, {{
+      type: 'line',
+      data: {{
+        labels: {json.dumps(labels)},
+        datasets: [{{
+          label: 'Return %',
+          data: {json.dumps(data)},
+          borderColor: 'rgb(75, 192, 192)',
+          tension: 0.1
+        }}]
+      }},
+      options: {{
+        scales: {{
+          y: {{
+            ticks: {{
+              callback: (value) => value + '%'
+            }}
+          }}
+        }}
+      }}
+    }});
+  </script>
+  <h2>Metrics</h2>
+  <table>
+    {table_rows}
+  </table>
+</body>
+</html>
+"""
+    return html
+
+
+def main(json_file: str, annual_rf: float, year: int, output: Path) -> None:
+    monthly, metrics = convert_to_monthly_and_calculate_ratios(
+        json_file=json_file, annual_rf=annual_rf, current_year=year
+    )
+    html = render_html(monthly, metrics)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(html, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate HTML performance report")
+    parser.add_argument("--json", default=JSON_FILE_PATH, help="Path to valuations JSON")
+    parser.add_argument("--rf", type=float, default=ANNUAL_RF_RATE, help="Annual risk-free rate")
+    parser.add_argument(
+        "--year", type=int, default=datetime.now().year, help="Current year for YTD calc"
+    )
+    parser.add_argument(
+        "--output", default="dist/index.html", help="Output HTML path (default: dist/index.html)"
+    )
+    args = parser.parse_args()
+    main(args.json, args.rf, args.year, Path(args.output))

--- a/tests/test_html_report.py
+++ b/tests/test_html_report.py
@@ -1,0 +1,19 @@
+import pandas as pd
+
+from scripts.build_report import render_html
+
+
+def test_render_html_contains_chart_and_metrics():
+    monthly = pd.Series([0.01, -0.02], index=pd.period_range("2024-01", periods=2, freq="M"))
+    metrics = {
+        "cagr": 0.1,
+        "max_dd_monthly": -0.02,
+        "ytd": 0.01,
+        "sharpe": 1.2,
+        "sortino": 1.5,
+    }
+    html = render_html(monthly, metrics)
+    assert "Portfolio Monthly Returns" in html
+    assert "CAGR" in html
+    assert "new Chart" in html
+    assert "2024-01" in html


### PR DESCRIPTION
## Summary
- build `scripts/build_report.py` to render monthly returns and key metrics as a Chart.js HTML page
- document and expose new `make report` command and set up workflow to publish report with GitHub Pages
- clarify that merging to `main` rebuilds `dist/index.html` and serves it at `https://<your-user>.github.io/capital/`

## Testing
- `PYTHONPATH=. pytest -q`
- `PYTHONPATH=. python scripts/build_report.py --output dist/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68be4330fc8083239d09be8805e6f0b1