### PR TITLE
feat: add cumulative performance chart

### DIFF
--- a/tests/test_html_report.py
+++ b/tests/test_html_report.py
@@ -19,5 +19,7 @@ def test_render_html_contains_sections_and_tables():
     assert "Portfolio Performance" in html
     assert "Benchmarks" in html
     assert "Monthly Performance" in html
+    assert "Cumulative Performance" in html
     assert "CAGR" in html
     assert "2024-01" in html
+    assert "perf-chart" in html


### PR DESCRIPTION
## Summary
- add cumulative performance column to monthly table
- plot cumulative portfolio, SPY, and QQQ returns
- handle benchmark fetch failures gracefully to allow report build even when market data is unavailable
- test HTML includes cumulative section and chart canvas

## Testing
- `PYTHONPATH=. pytest -q`
- `python scripts/build_report.py --output dist/index.html` *(warns: Failed to get ticker 'SPY' and 'QQQ' due to 403 proxy errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6c9e446c8323ac162c3b9a3da38c