### PR TITLE
fix: streamline monthly report

### DIFF
--- a/tests/test_html_report.py
+++ b/tests/test_html_report.py
@@ -20,6 +20,8 @@ def test_render_html_contains_sections_and_tables():
     assert "Benchmarks" in html
     assert "Monthly Performance" in html
     assert "Cumulative Performance" in html
+    assert "<th class=\"py-2 px-3 text-left text-sm font-semibold text-slate-700\">Cumulative</th>" not in html
+    assert "-1.02%" in html
     assert "CAGR" in html
     assert "2024-01" in html
     assert "perf-chart" in html


### PR DESCRIPTION
## Summary
- drop cumulative column from monthly performance table and show since-inception totals in portfolio, SPY and QQQ columns
- compute chart y-axis range dynamically to avoid excessive negative scale
- add regression test covering since-inception totals and absence of cumulative column

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bf71523f208323b59d944b21eb7bc8