### PR TITLE
feat: link report footer to GitHub

### DIFF
--- a/scripts/build_report.py
+++ b/scripts/build_report.py
@@ -276,7 +276,7 @@ def render_html(
     </section>
 
     <footer class=\"mt-10 text-sm text-slate-500\">
-      <p>Source: SavvyTrader valuations JSON. RF: {ANNUAL_RF_RATE:.2%} annual.</p>
+      <a href=\"https://github.com/mingdom/capital\" class=\"hover:underline\">View source on GitHub</a>
     </footer>
   </main>
   <script src=\"https://cdn.jsdelivr.net/npm/chart.js\"></script>


### PR DESCRIPTION
## Summary
- Replace report footer text with link to the project's GitHub repository for more info

## Testing
- `PYTHONPATH=. ./venv/bin/pytest -q`
- `./venv/bin/python scripts/build_report.py --output dist/index.html` *(fails to fetch SPY/QQQ tickers due to 403, but report generated)*

------
https://chatgpt.com/codex/tasks/task_e_68bf73c73cfc8323a9ce9d45c1a70b5f